### PR TITLE
perf: use prettyPrint=false by default

### DIFF
--- a/google/cloud/_http.py
+++ b/google/cloud/_http.py
@@ -211,8 +211,12 @@ class JSONConnection(Connection):
         )
 
         query_params = query_params or {}
-        if query_params:
-            url += "?" + urlencode(query_params, doseq=True)
+
+        if "prettyPrint" not in query_params:
+            query_params = query_params.copy()
+            query_params["prettyPrint"] = "false"
+
+        url += "?" + urlencode(query_params, doseq=True)
 
         return url
 

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -184,8 +184,15 @@ class TestJSONConnection(unittest.TestCase):
         client = object()
         conn = self._make_mock_one(client)
         # Intended to emulate self.mock_template
-        URI = "/".join([conn.API_BASE_URL, "mock", conn.API_VERSION, "foo"])
+        URI = "/".join([conn.API_BASE_URL, "mock", conn.API_VERSION, "foo?prettyPrint=false"])
         self.assertEqual(conn.build_api_url("/foo"), URI)
+
+    def test_build_api_url_w_pretty_print_query_params(self):
+        client = object()
+        conn = self._make_mock_one(client)
+        uri = conn.build_api_url("/foo", {"prettyPrint": "true"})
+        URI = "/".join([conn.API_BASE_URL, "mock", conn.API_VERSION, "foo?prettyPrint=true"])
+        self.assertEqual(uri, URI)
 
     def test_build_api_url_w_extra_query_params(self):
         from six.moves.urllib.parse import parse_qs
@@ -319,7 +326,7 @@ class TestJSONConnection(unittest.TestCase):
             "User-Agent": conn.user_agent,
             CLIENT_INFO_HEADER: conn.user_agent,
         }
-        expected_url = "{base}/mock/{version}{path}".format(
+        expected_url = "{base}/mock/{version}{path}?prettyPrint=false".format(
             base=conn.API_BASE_URL, version=conn.API_VERSION, path=path
         )
         http.request.assert_called_once_with(
@@ -481,7 +488,7 @@ class TestJSONConnection(unittest.TestCase):
             "User-Agent": conn.user_agent,
             CLIENT_INFO_HEADER: conn.user_agent,
         }
-        expected_url = "{base}/mock/{version}{path}".format(
+        expected_url = "{base}/mock/{version}{path}?prettyPrint=false".format(
             base=conn.API_BASE_URL, version=conn.API_VERSION, path=path
         )
         http.request.assert_called_once_with(


### PR DESCRIPTION
This tells One Platform APIs not to use excessive whitespace in
responses. For some reason, the backend defaults to prettyPrint=true and
does not provide a mechanism for overriding this.

In response to internal customer issue 168522192.

Tested locally against `google-cloud-bigquery` system and sample tests.