### PR TITLE
chore: release v1.4.2rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@
 
 * update docs build (via synth) ([#14](https://www.github.com/googleapis/python-cloud-core/issues/14)) ([f1a95ce](https://www.github.com/googleapis/python-cloud-core/commit/f1a95ce89c25f5297470299ca1ef7e1e05a9e99f))
 
+
+## 1.4.2rc2
+
+09-24-2020 09:29 PDT
+
+### Implementation Changes
+
+- fix: handle query_params tuples in JSONConnection.build_api_url ([#34](https://github.com/googleapis/python-cloud-core/pull/34))
+
+### Internal / Testing Changes
+
+- chore: add default CODEOWNERS ([#33](https://github.com/googleapis/python-cloud-core/pull/33))
+
+
 ## 1.4.2rc1
 
 09-21-2020 14:45 PDT

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import setuptools
 
 name = "google-cloud-core"
 description = "Google Cloud API client core library"
-version = "1.4.2rc1"
+version = "1.4.2rc2"
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'


### PR DESCRIPTION
After this pre-release and before merging real v1.4.2, I will update the following PRs to double-check this won't break clients:

- https://github.com/googleapis/python-bigquery/pull/276
- https://github.com/googleapis/python-logging/pull/66
- https://github.com/googleapis/python-translate/pull/69
- https://github.com/googleapis/python-storage/pull/277
- https://github.com/googleapis/python-runtimeconfig/pull/23
- https://github.com/googleapis/python-dns/pull/23
- https://github.com/googleapis/python-resource-manager/pull/31