### PR TITLE
chore: tweak 'python_requires' to match supported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setuptools.setup(
     namespace_packages=namespaces,
     install_requires=dependencies,
     extras_require=extras,
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*",
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
Bump required version of  'google-api-core' to match.

Release-As: 1.5.0