### PR TITLE
chore: use Python 3.8 for docs / docfx sessions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -106,7 +106,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python="3.8")
 def docs(session):
     """Build the docs for this library."""
 
@@ -129,7 +129,7 @@ def docs(session):
     )
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+@nox.session(python="3.8")
 def docfx(session):
     """Build the docfx yaml files for this library."""
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -112,7 +112,7 @@ def docs(session):
 
     session.install(".", "grpcio >= 1.8.2", "grpcio-gcp >= 0.2.2")
     session.install("-e", ".")
-    session.install("sphinx", "alabaster", "recommonmark")
+    session.install("sphinx==4.0.1", "alabaster", "recommonmark")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(
@@ -134,7 +134,9 @@ def docfx(session):
     """Build the docfx yaml files for this library."""
 
     session.install("-e", ".")
-    session.install("sphinx", "alabaster", "recommonmark", "sphinx-docfx-yaml")
+    session.install(
+        "sphinx==4.0.1", "alabaster", "recommonmark", "gcp-sphinx-docfx-yaml",
+    )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(


### PR DESCRIPTION
Works around recent changes to the Kokoro 'docs-presubmt' configuration.

See: https://github.com/googleapis/python-api-core/pull/224