### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,10 +1,12 @@
 {
-  "name": "google-cloud-core",
-  "name_pretty": "Google API client core library",
-  "client_documentation": "https://googleapis.dev/python/google-cloud-core/latest",
-  "release_level": "ga",
-  "language": "python",
-  "library_type": "CORE",
-  "repo": "googleapis/python-cloud-core",
-  "distribution_name": "google-cloud-core"
+    "name": "google-cloud-core",
+    "name_pretty": "Google API client core library",
+    "client_documentation": "https://googleapis.dev/python/google-cloud-core/latest",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "CORE",
+    "repo": "googleapis/python-cloud-core",
+    "distribution_name": "google-cloud-core",
+    "default_version": "",
+    "codeowner_team": ""
 }


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114
