### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "google-cloud-core",
     "name_pretty": "Google API client core library",
-    "client_documentation": "https://googleapis.dev/python/google-cloud-core/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/google-cloud-core/latest",
     "release_level": "ga",
     "language": "python",
     "library_type": "CORE",

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ common helpers (e.g. base ``Client`` classes) used by all of the
    :target: https://pypi.org/project/google-cloud-core/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-core.svg
    :target: https://pypi.org/project/google-cloud-core/
-.. _Documentation: https://googleapis.dev/python/google-cloud-core/latest
+.. _Documentation: https://cloud.google.com/python/docs/reference/google-cloud-core/latest
 
 Quick Start
 -----------


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.