### PR TITLE
feat: allow extra_api_info to be passed to api request

### DIFF
--- a/google/cloud/_http/__init__.py
+++ b/google/cloud/_http/__init__.py
@@ -282,6 +282,7 @@ class JSONConnection(Connection):
         headers=None,
         target_object=None,
         timeout=_DEFAULT_TIMEOUT,
+        extra_api_info=None,
     ):
         """A low level method to send a request to the API.
 
@@ -327,7 +328,10 @@ class JSONConnection(Connection):
         if content_type:
             headers["Content-Type"] = content_type
 
-        headers[CLIENT_INFO_HEADER] = self.user_agent
+        if extra_api_info:
+            headers[CLIENT_INFO_HEADER] = f"{self.user_agent} {extra_api_info}"
+        else:
+            headers[CLIENT_INFO_HEADER] = self.user_agent
         headers["User-Agent"] = self.user_agent
 
         return self._do_request(
@@ -385,6 +389,7 @@ class JSONConnection(Connection):
         expect_json=True,
         _target_object=None,
         timeout=_DEFAULT_TIMEOUT,
+        extra_api_info=None,
     ):
         """Make a request over the HTTP transport to the API.
 
@@ -474,6 +479,7 @@ class JSONConnection(Connection):
             headers=headers,
             target_object=_target_object,
             timeout=timeout,
+            extra_api_info=extra_api_info,
         )
 
         if not 200 <= response.status_code < 300:

--- a/google/cloud/_http/__init__.py
+++ b/google/cloud/_http/__init__.py
@@ -318,6 +318,10 @@ class JSONConnection(Connection):
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
 
+        :type extra_api_info: string
+        :param extra_api_info: (optional) Extra api info to be appended to
+            the X-Goog-API-Client header
+
         :rtype: :class:`requests.Response`
         :returns: The HTTP response.
         """
@@ -450,6 +454,10 @@ class JSONConnection(Connection):
 
             Can also be passed as a tuple (connect_timeout, read_timeout).
             See :meth:`requests.Session.request` documentation for details.
+
+        :type extra_api_info: string
+        :param extra_api_info: (optional) Extra api info to be appended to
+            the X-Goog-API-Client header
 
         :raises ~google.cloud.exceptions.GoogleCloudError: if the response code
             is not 200 OK.

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -574,6 +574,31 @@ class TestJSONConnection(unittest.TestCase):
             data=None,
             timeout=(2.2, 3.3),
         )
+    
+    def test_api_request_w_extra_api_info(self):
+        from google.cloud._http import CLIENT_INFO_HEADER
+
+        session = make_requests_session([self.EMPTY_JSON_RESPONSE])
+        client = mock.Mock(_http=session, spec=["_http"])
+        conn = self._make_mock_one(client)
+
+        EXTRA_API_INFO="gccl-invocation-id/testing-id-123"
+        result = conn.api_request("GET", "/", extra_api_info=EXTRA_API_INFO)
+
+        self.assertEqual(result, {})
+
+        expected_headers = {
+            "Accept-Encoding": "gzip",
+            "User-Agent": conn.user_agent,
+            CLIENT_INFO_HEADER: f"{conn.user_agent} {EXTRA_API_INFO}",
+        }
+        session.request.assert_called_once_with(
+            method="GET",
+            url=mock.ANY,
+            headers=expected_headers,
+            data=None,
+            timeout=self._get_default_timeout(),
+        )
 
     def test_api_request_w_404(self):
         from google.cloud import exceptions

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -574,7 +574,7 @@ class TestJSONConnection(unittest.TestCase):
             data=None,
             timeout=(2.2, 3.3),
         )
-    
+
     def test_api_request_w_extra_api_info(self):
         from google.cloud._http import CLIENT_INFO_HEADER
 
@@ -582,7 +582,7 @@ class TestJSONConnection(unittest.TestCase):
         client = mock.Mock(_http=session, spec=["_http"])
         conn = self._make_mock_one(client)
 
-        EXTRA_API_INFO="gccl-invocation-id/testing-id-123"
+        EXTRA_API_INFO = "gccl-invocation-id/testing-id-123"
         result = conn.api_request("GET", "/", extra_api_info=EXTRA_API_INFO)
 
         self.assertEqual(result, {})


### PR DESCRIPTION
In order to track retry metrics, we need to add extra information to the X-Goog-API-Client header.

https://docs.google.com/document/d/1xo1OlU2ESmVYUgpfn5FjCpRoH-f6JXxlRTQg_2FEdTQ/edit?resourcekey=0-hwjKNEbdT01zQ7QsZG3Srw

This is in line with how it is done in other parts of cloud such as cloud sdk.

This PR adds an extra argument to Connection.api_request and _make_request that allows for this extra_api_info to be passed in.