### PR TITLE
chore: test minimum dependencies in python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ description = "Google Cloud API client core library"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
+    "google-api-core >= 1.31.6, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "google-auth >= 1.25.0, < 3.0dev",
 ]
 extras = {"grpc": "grpcio >= 1.8.2, < 2.0dev"}

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -5,6 +5,6 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-google-api-core==1.31.5
+google-api-core==1.31.6
 google-auth==1.25.0
 grpcio==1.8.2

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -1,0 +1,10 @@
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have foo==1.14.0
+google-api-core==1.31.5
+google-auth==1.25.0
+grpcio==1.8.2

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -5,6 +5,6 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-google-api-core==1.31.5
+google-api-core==1.31.6
 google-auth==1.25.0
 grpcio==1.8.2


### PR DESCRIPTION
Test the minimum supported dependencies in python 3.7 unit tests to prepare for dropping python 3.6

fix(deps): require google-api-core>=1.31.6