### PR TITLE
fix: Add grpcio-status to grpc extras

### DIFF
--- a/google/cloud/_helpers/__init__.py
+++ b/google/cloud/_helpers/__init__.py
@@ -39,7 +39,7 @@ except ImportError:  # pragma: NO COVER
     grpc = None
 
 
-_NOW = datetime.datetime.utcnow  # To be replaced by tests.
+_NOW = datetime.datetime.now(datetime.timezone.utc)
 UTC = datetime.timezone.utc  # Singleton instance to be used throughout.
 _EPOCH = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -73,8 +73,8 @@ def default(session):
     )
 
     # Install all test dependencies, then install local packages in-place.
-    session.install("pytest", "pytest-cov", "grpcio >= 1.0.2", "-c", constraints_path)
-    session.install("-e", ".", "-c", constraints_path)
+    session.install("pytest", "pytest-cov", "-c", constraints_path)
+    session.install("-e", ".[grpc]", "-c", constraints_path)
 
     # Run py.test against the unit tests.
     session.run(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+filterwarnings =
+    # treat all warnings as errors
+    error
+    # Remove once https://github.com/protocolbuffers/protobuf/issues/12186 is fixed
+    ignore:.*custom tp_new.*in Python 3.14:DeprecationWarning
+    # Remove once Release PR https://github.com/googleapis/python-api-common-protos/pull/191 is merged
+    ignore:.*pkg_resources.declare_namespace:DeprecationWarning
+    ignore:.*pkg_resources is deprecated as an API:DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,12 @@ dependencies = [
     "google-auth >= 1.25.0, < 3.0dev",
     "importlib-metadata > 1.0.0; python_version<'3.8'",
 ]
-extras = {"grpc": "grpcio >= 1.38.0, < 2.0dev"}
-
+extras = {
+    "grpc": [
+        "grpcio >= 1.38.0, < 2.0dev",
+        "grpcio-status >= 1.38.0, < 2.0.dev0",
+    ],
+}
 
 # Setup boilerplate below this line.
 

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -138,7 +138,7 @@ class Test__millis_from_datetime(unittest.TestCase):
         from google.cloud._helpers import UTC
         from google.cloud._helpers import _microseconds_from_datetime
 
-        NOW = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        NOW = datetime.datetime.now().replace(tzinfo=UTC)
         NOW_MICROS = _microseconds_from_datetime(NOW)
         MILLIS = NOW_MICROS // 1000
         result = self._call_fut(NOW)
@@ -163,7 +163,7 @@ class Test__millis_from_datetime(unittest.TestCase):
         from google.cloud._helpers import UTC
         from google.cloud._helpers import _microseconds_from_datetime
 
-        NOW = datetime.datetime.utcnow()
+        NOW = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         UTC_NOW = NOW.replace(tzinfo=UTC)
         UTC_NOW_MICROS = _microseconds_from_datetime(UTC_NOW)
         MILLIS = UTC_NOW_MICROS // 1000


### PR DESCRIPTION

build: treat warnings as errors


Add grpcio-status to grpc extras to address the warning from `google-api-core` : `Please install grpcio-status to obtain helpful grpc error messages`
https://github.com/googleapis/python-api-core/blob/42e8b6e6f426cab749b34906529e8aaf3f133d75/google/api_core/exceptions.py#L38