### PR TITLE
fix: add type hints to client

### DIFF
--- a/google/cloud/_helpers/__init__.py
+++ b/google/cloud/_helpers/__init__.py
@@ -17,15 +17,13 @@
 This module is not part of the public API surface.
 """
 
-from __future__ import absolute_import
-
 import calendar
 import datetime
 import http.client
 import os
 import re
 from threading import local as Local
-from typing import Union
+from typing import Optional, Union
 
 import google.auth
 import google.auth.transport.requests

--- a/google/cloud/_helpers/__init__.py
+++ b/google/cloud/_helpers/__init__.py
@@ -136,7 +136,7 @@ def _ensure_tuple_or_list(arg_name, tuple_or_list):
     return list(tuple_or_list)
 
 
-def _determine_default_project(project=None):
+def _determine_default_project(project: Optional[str] = None):
     """Determine default project ID explicitly or implicitly as fall-back.
 
     See :func:`google.auth.default` for details on how the default project

--- a/google/cloud/client/__init__.py
+++ b/google/cloud/client/__init__.py
@@ -49,7 +49,7 @@ class _ClientFactoryMixin(object):
     _SET_PROJECT = False
 
     @classmethod
-    def from_service_account_info(cls, info: dict, *args, **kwargs) -> Self:
+    def from_service_account_info(cls, info, *args, **kwargs) -> Self:
         """Factory to retrieve JSON credentials while creating client.
 
         :type info: dict

--- a/google/cloud/client/__init__.py
+++ b/google/cloud/client/__init__.py
@@ -18,7 +18,7 @@ import io
 import json
 import os
 from pickle import PicklingError
-from typing import Optional, Tuple, Union
+from typing import Optional, Self, Tuple, Union
 
 import requests
 
@@ -55,7 +55,7 @@ class _ClientFactoryMixin(object):
     _SET_PROJECT = False
 
     @classmethod
-    def from_service_account_info(cls, info, *args, **kwargs):
+    def from_service_account_info(cls, info: dict, *args, **kwargs) -> Self:
         """Factory to retrieve JSON credentials while creating client.
 
         :type info: dict
@@ -85,7 +85,7 @@ class _ClientFactoryMixin(object):
         return cls(*args, **kwargs)
 
     @classmethod
-    def from_service_account_json(cls, json_credentials_path, *args, **kwargs):
+    def from_service_account_json(cls, json_credentials_path: str, *args, **kwargs):
         """Factory to retrieve JSON credentials while creating client.
 
         :type json_credentials_path: str
@@ -185,6 +185,8 @@ class Client(_ClientFactoryMixin):
             else:
                 credentials, _ = google.auth.default(scopes=scopes)
 
+        assert isinstance(credentials, google.auth.credentials.Credentials)
+        assert scopes is not None
         self._credentials = google.auth.credentials.with_scopes_if_required(
             credentials, scopes=scopes
         )
@@ -284,16 +286,10 @@ class _ClientProjectMixin(object):
                 "determined from the environment."
             )
 
-        if isinstance(project, bytes):
-            project = project.decode("utf-8")
-
-        if not isinstance(project, str):
-            raise ValueError("Project must be a string.")
-
         self.project = project
 
     @staticmethod
-    def _determine_default(project):
+    def _determine_default(project: Optional[str]) -> Optional[str]:
         """Helper:  use default project detection."""
         return _determine_default_project(project)
 
@@ -332,7 +328,7 @@ class ClientWithProject(Client, _ClientProjectMixin):
         project: Optional[str] = None,
         credentials: Optional[Credentials] = None,
         client_options: Optional[ClientOptions] = None,
-        _http=None,
+        _http: Optional[requests.Session] = None,
     ):
         _ClientProjectMixin.__init__(self, project=project, credentials=credentials)
         Client.__init__(

--- a/google/cloud/client/__init__.py
+++ b/google/cloud/client/__init__.py
@@ -18,14 +18,16 @@ import io
 import json
 import os
 from pickle import PicklingError
-from typing import Tuple
+from typing import Optional, Tuple
 from typing import Union
 
 import google.api_core.client_options
+from google.api_core.client_options import ClientOptions
 import google.api_core.exceptions
 import google.auth
 from google.auth import environment_vars
 import google.auth.credentials
+from google.auth.credentials import Credentials
 import google.auth.transport.requests
 from google.cloud._helpers import _determine_default_project
 from google.oauth2 import service_account
@@ -150,7 +152,12 @@ class Client(_ClientFactoryMixin):
     Needs to be set by subclasses.
     """
 
-    def __init__(self, credentials=None, _http=None, client_options=None):
+    def __init__(
+        self,
+        credentials: Optional[Credentials] = None,
+        _http=None,
+        client_options: Optional[ClientOptions] = None,
+    ):
         if isinstance(client_options, dict):
             client_options = google.api_core.client_options.from_dict(client_options)
         if client_options is None:
@@ -248,7 +255,9 @@ class _ClientProjectMixin(object):
              if the project value is invalid.
     """
 
-    def __init__(self, project=None, credentials=None):
+    def __init__(
+        self, project: Optional[str] = None, credentials: Optional[Credentials] = None
+    ):
         # This test duplicates the one from `google.auth.default`, but earlier,
         # for backward compatibility:  we want the environment variable to
         # override any project set on the credentials.  See:
@@ -316,7 +325,13 @@ class ClientWithProject(Client, _ClientProjectMixin):
 
     _SET_PROJECT = True  # Used by from_service_account_json()
 
-    def __init__(self, project=None, credentials=None, client_options=None, _http=None):
+    def __init__(
+        self,
+        project: Optional[str] = None,
+        credentials: Optional[Credentials] = None,
+        client_options: Optional[ClientOptions] = None,
+        _http=None,
+    ):
         _ClientProjectMixin.__init__(self, project=project, credentials=credentials)
         Client.__init__(
             self, credentials=credentials, client_options=client_options, _http=_http

--- a/google/cloud/client/__init__.py
+++ b/google/cloud/client/__init__.py
@@ -162,8 +162,8 @@ class Client(_ClientFactoryMixin):
         if isinstance(client_options, dict):
             client_options = google.api_core.client_options.from_dict(client_options)
         if client_options is None:
-            client_options = google.api_core.client_options.ClientOptions()
-        assert isinstance(client_options, google.api_core.client_options.ClientOptions)
+            client_options = ClientOptions()
+        assert isinstance(client_options, ClientOptions)
 
         if credentials and client_options.credentials_file:
             raise google.api_core.exceptions.DuplicateCredentialArgs(

--- a/google/cloud/client/__init__.py
+++ b/google/cloud/client/__init__.py
@@ -28,7 +28,6 @@ import google.api_core.exceptions
 import google.auth
 from google.auth import environment_vars
 import google.auth.credentials
-from google.auth.credentials import Credentials, CredentialsWithQuotaProject
 import google.auth.transport.requests
 from google.cloud._helpers import _determine_default_project
 from google.oauth2 import service_account
@@ -149,7 +148,7 @@ class Client(_ClientFactoryMixin):
 
     def __init__(
         self,
-        credentials: Optional[Credentials] = None,
+        credentials: Optional[google.auth.credentials.Credentials] = None,
         _http: Optional[requests.Session] = None,
         client_options: Union[ClientOptions, Dict[str, Any], None] = None,
     ):
@@ -182,7 +181,9 @@ class Client(_ClientFactoryMixin):
         )
 
         if client_options.quota_project_id:
-            assert isinstance(self._credentials, CredentialsWithQuotaProject)
+            assert isinstance(
+                self._credentials, google.auth.credentials.CredentialsWithQuotaProject
+            )
             self._credentials = self._credentials.with_quota_project(
                 client_options.quota_project_id
             )
@@ -250,7 +251,9 @@ class _ClientProjectMixin(object):
     """
 
     def __init__(
-        self, project: Optional[str] = None, credentials: Optional[Credentials] = None
+        self,
+        project: Optional[str] = None,
+        credentials: Optional[google.auth.credentials.Credentials] = None,
     ):
         # This test duplicates the one from `google.auth.default`, but earlier,
         # for backward compatibility:  we want the environment variable to
@@ -316,7 +319,7 @@ class ClientWithProject(Client, _ClientProjectMixin):
     def __init__(
         self,
         project: Optional[str] = None,
-        credentials: Optional[Credentials] = None,
+        credentials: Optional[google.auth.credentials.Credentials] = None,
         client_options: Optional[ClientOptions] = None,
         _http: Optional[requests.Session] = None,
     ):

--- a/google/cloud/client/__init__.py
+++ b/google/cloud/client/__init__.py
@@ -34,12 +34,6 @@ from google.cloud._helpers import _determine_default_project
 from google.oauth2 import service_account
 
 
-_GOOGLE_AUTH_CREDENTIALS_HELP = (
-    "This library only supports credentials from google-auth-library-python. "
-    "See https://google-auth.readthedocs.io/en/latest/ "
-    "for help on authentication with this library."
-)
-
 # Default timeout for auth requests.
 _CREDENTIALS_REFRESH_TIMEOUT = 300
 
@@ -169,9 +163,6 @@ class Client(_ClientFactoryMixin):
             raise google.api_core.exceptions.DuplicateCredentialArgs(
                 "'credentials' and 'client_options.credentials_file' are mutually exclusive."
             )
-
-        if credentials is not None:
-            raise ValueError(_GOOGLE_AUTH_CREDENTIALS_HELP)
 
         scopes = client_options.scopes or self.SCOPE
 

--- a/google/cloud/client/__init__.py
+++ b/google/cloud/client/__init__.py
@@ -18,7 +18,7 @@ import io
 import json
 import os
 from pickle import PicklingError
-from typing import Optional, Self, Tuple, Union
+from typing import Any, Dict, Optional, Self, Tuple, Union
 
 import requests
 
@@ -157,21 +157,20 @@ class Client(_ClientFactoryMixin):
         self,
         credentials: Optional[Credentials] = None,
         _http: Optional[requests.Session] = None,
-        client_options: Optional[ClientOptions] = None,
+        client_options: Union[ClientOptions, Dict[str, Any], None] = None,
     ):
         if isinstance(client_options, dict):
             client_options = google.api_core.client_options.from_dict(client_options)
         if client_options is None:
             client_options = google.api_core.client_options.ClientOptions()
+        assert isinstance(client_options, google.api_core.client_options.ClientOptions)
 
         if credentials and client_options.credentials_file:
             raise google.api_core.exceptions.DuplicateCredentialArgs(
                 "'credentials' and 'client_options.credentials_file' are mutually exclusive."
             )
 
-        if credentials and not isinstance(
-            credentials, google.auth.credentials.Credentials
-        ):
+        if credentials is not None:
             raise ValueError(_GOOGLE_AUTH_CREDENTIALS_HELP)
 
         scopes = client_options.scopes or self.SCOPE

--- a/google/cloud/client/__init__.py
+++ b/google/cloud/client/__init__.py
@@ -18,8 +18,9 @@ import io
 import json
 import os
 from pickle import PicklingError
-from typing import Optional, Tuple
-from typing import Union
+from typing import Optional, Tuple, Union
+
+import requests
 
 import google.api_core.client_options
 from google.api_core.client_options import ClientOptions
@@ -27,7 +28,7 @@ import google.api_core.exceptions
 import google.auth
 from google.auth import environment_vars
 import google.auth.credentials
-from google.auth.credentials import Credentials
+from google.auth.credentials import Credentials, CredentialsWithQuotaProject
 import google.auth.transport.requests
 from google.cloud._helpers import _determine_default_project
 from google.oauth2 import service_account
@@ -155,7 +156,7 @@ class Client(_ClientFactoryMixin):
     def __init__(
         self,
         credentials: Optional[Credentials] = None,
-        _http=None,
+        _http: Optional[requests.Session] = None,
         client_options: Optional[ClientOptions] = None,
     ):
         if isinstance(client_options, dict):
@@ -189,6 +190,7 @@ class Client(_ClientFactoryMixin):
         )
 
         if client_options.quota_project_id:
+            assert isinstance(self._credentials, CredentialsWithQuotaProject)
             self._credentials = self._credentials.with_quota_project(
                 client_options.quota_project_id
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pyright]
+typeCheckingMode = "strict"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.pyright]
-typeCheckingMode = "strict"


### PR DESCRIPTION
Enables https://github.com/googleapis/python-storage/pull/1362.

I checked:

- [x] `mypy -p google.cloud._helpers`
- [x] `mypy -p google.cloud.client`

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-cloud-core/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
