### PR TITLE
chore: librarian release pull request: 20251113T220038Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,8 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: google-cloud-core
-    version: 2.5.0
+    version: 2.6.0
+    last_generated_commit: ""
     apis: []
     source_roots:
       - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-cloud-core/#history
 
+## [2.6.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-core-v2.5.0...google-cloud-core-v2.6.0) (2025-11-13)
+
+
+### Features
+
+* some feature ([baec49ff8242ef6eb41ca95322593ae633cb6cfe](https://github.com/googleapis/google-cloud-python/commit/baec49ff8242ef6eb41ca95322593ae633cb6cfe))
+
 ## [2.5.0](https://github.com/googleapis/python-cloud-core/compare/v2.4.3...v2.5.0) (2025-10-27)
 
 

--- a/google/cloud/version.py
+++ b/google/cloud/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.5.0"
+__version__ = "2.6.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.6.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>google-cloud-core: 2.6.0</summary>

## [2.6.0](https://github.com/googleapis/python-cloud-core/compare/v2.5.0...v2.6.0) (2025-11-13)

### Features

* some feature ([baec49ff](https://github.com/googleapis/python-cloud-core/commit/baec49ff))

</details>