### PR TITLE
tests: update default python runtime for tests to 3.14

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.14"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.14"
     - name: Install nox
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.14"
     - name: Install coverage
       run: |
         python -m pip install --upgrade setuptools pip wheel

--- a/noxfile.py
+++ b/noxfile.py
@@ -122,6 +122,8 @@ def cover(session):
     session.run("coverage", "erase")
 
 
+# Keep docs session at Python 3.10 until
+# https://github.com/googleapis/sphinx-docfx-yaml/issues/345 is fixed
 @nox.session(python="3.10")
 def docs(session):
     """Build the docs for this library."""
@@ -158,6 +160,8 @@ def docs(session):
     )
 
 
+# Keep docfx session at Python 3.10 until
+# https://github.com/googleapis/sphinx-docfx-yaml/issues/345 is fixed
 @nox.session(python="3.10")
 def docfx(session):
     """Build the docfx yaml files for this library."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,14 +22,14 @@ import nox
 BLACK_VERSION = "black==23.7.0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION = "3.8"
+DEFAULT_PYTHON_VERSION = "3.14"
 CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 
 # Error if a python version is missing
 nox.options.error_on_missing_interpreters = True
 
 
-@nox.session(python="3.10")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def lint(session):
     """Run linters.
 
@@ -102,7 +102,7 @@ def unit(session):
     default(session)
 
 
-@nox.session(python="3.10")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -106,7 +106,7 @@ def unit(session):
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
 
-    session.install("docutils", "Pygments")
+    session.install("docutils", "Pygments", "setuptools")
     session.run("python", "setup.py", "check", "--restructuredtext", "--strict")
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,10 +9,7 @@ filterwarnings =
     # Remove once the minimum supported version of `google-api-core` is 2.15.0
     ignore:.*pkg_resources.declare_namespace:DeprecationWarning
     ignore:.*pkg_resources is deprecated as an API:DeprecationWarning
-    # Remove after support for Python 3.8 is dropped
-    ignore:You are using a non-supported Python version \(3\.8:DeprecationWarning
-    ignore:You are using a non-supported Python version \(3\.8:FutureWarning
-    # Remove after support for Python 3.9 is dropped
-    ignore:You are using a Python version \(3\.9:FutureWarning
-    # Remove after support for Python 3.10 is dropped
-    ignore:.*You are using a Python version \(3\.10:FutureWarning
+    # Remove after support for Python 3.8/3.9 is dropped
+    ignore:You are using a non-supported Python version:DeprecationWarning
+    ignore:You are using a non-supported Python version:FutureWarning
+    ignore:You are using a Python version:FutureWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,7 +9,6 @@ filterwarnings =
     # Remove once the minimum supported version of `google-api-core` is 2.15.0
     ignore:.*pkg_resources.declare_namespace:DeprecationWarning
     ignore:.*pkg_resources is deprecated as an API:DeprecationWarning
-    # Remove after support for Python 3.8/3.9 is dropped
-    ignore:You are using a non-supported Python version:DeprecationWarning
-    ignore:You are using a non-supported Python version:FutureWarning
-    ignore:You are using a Python version:FutureWarning
+    # Remove after support for Python 3.8, 3.9 and/or 3.10+ is dropped
+    ignore:\s*You are using a (non-supported )?Python version \(?3\.(8|9|1[0-9]+):DeprecationWarning
+    ignore:\s*You are using a (non-supported )?Python version \(?3\.(8|9|1[0-9]+):FutureWarning


### PR DESCRIPTION
Similar to https://github.com/googleapis/python-api-core/pull/870